### PR TITLE
Use correct comment Syntax in Appkernel

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -42,7 +42,7 @@ class AppKernel extends Kernel
 
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getRootDir ()
     {
@@ -52,7 +52,7 @@ class AppKernel extends Kernel
 
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getCacheDir ()
     {
@@ -62,7 +62,7 @@ class AppKernel extends Kernel
 
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getLogDir ()
     {
@@ -72,7 +72,7 @@ class AppKernel extends Kernel
 
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function registerContainerConfiguration (LoaderInterface $loader)
     {


### PR DESCRIPTION
Use the new, correct @inheritdoc syntax instead of the old syntax.